### PR TITLE
Fix: Updated print statement to reflect correct model file name

### DIFF
--- a/train_model.py
+++ b/train_model.py
@@ -49,4 +49,4 @@ history = model.fit(
     callbacks=[checkpoint]
 )
 
-print("Training complete. Model saved as 'asl_cnn_model.h5'.")
+print("Training complete. Model saved as 'asl_cnn_model.keras'.")


### PR DESCRIPTION
Updated the print message to correctly say the model is saved as asl_cnn_model.keras instead of asl_cnn_model.h5.